### PR TITLE
Add /clear and /compact slash commands with keychain caching

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -785,17 +785,70 @@ struct StoredAuth {
     expires_at: Option<i64>,
 }
 
+// ── In-memory + file cache for keychain credentials ──
+// Avoids repeated macOS keychain password prompts on every access.
+
+fn auth_cache() -> &'static Mutex<Option<StoredAuth>> {
+    static CACHE: OnceLock<Mutex<Option<StoredAuth>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+fn auth_file_cache_path() -> PathBuf {
+    snailer_home_dir().join("auth_cache.json")
+}
+
+fn auth_file_cache_read() -> Option<StoredAuth> {
+    let path = auth_file_cache_path();
+    let text = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str::<StoredAuth>(&text).ok()
+}
+
+fn auth_file_cache_write(value: &StoredAuth) {
+    let path = auth_file_cache_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(text) = serde_json::to_string(value) {
+        let _ = std::fs::write(&path, text);
+    }
+}
+
+fn auth_file_cache_clear() {
+    let _ = std::fs::remove_file(auth_file_cache_path());
+}
+
 fn auth_keychain_entry() -> Result<keyring::Entry, String> {
     keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_AUTH_KEY)
         .map_err(|e| format!("keychain init failed: {}", e))
 }
 
 fn auth_keychain_get() -> Result<Option<StoredAuth>, String> {
+    // 1. Check in-memory cache first (no keychain prompt).
+    if let Ok(guard) = auth_cache().lock() {
+        if let Some(ref cached) = *guard {
+            return Ok(Some(cached.clone()));
+        }
+    }
+
+    // 2. Check file cache (no keychain prompt).
+    if let Some(cached) = auth_file_cache_read() {
+        if let Ok(mut guard) = auth_cache().lock() {
+            *guard = Some(cached.clone());
+        }
+        return Ok(Some(cached));
+    }
+
+    // 3. Fall back to keychain (may prompt once).
     let entry = auth_keychain_entry()?;
     match entry.get_password() {
         Ok(text) => {
             let v = serde_json::from_str::<StoredAuth>(&text)
                 .map_err(|e| format!("keychain data invalid: {}", e))?;
+            // Populate both caches so we never prompt again.
+            auth_file_cache_write(&v);
+            if let Ok(mut guard) = auth_cache().lock() {
+                *guard = Some(v.clone());
+            }
             Ok(Some(v))
         }
         Err(e) => {
@@ -810,15 +863,25 @@ fn auth_keychain_get() -> Result<Option<StoredAuth>, String> {
 }
 
 fn auth_keychain_set(value: &StoredAuth) -> Result<(), String> {
+    // Update all three: keychain, file cache, memory cache.
     let entry = auth_keychain_entry()?;
     let text = serde_json::to_string(value).map_err(|e| format!("serialize failed: {}", e))?;
     entry
         .set_password(&text)
         .map_err(|e| format!("keychain write failed: {}", e))?;
+    auth_file_cache_write(value);
+    if let Ok(mut guard) = auth_cache().lock() {
+        *guard = Some(value.clone());
+    }
     Ok(())
 }
 
 fn auth_keychain_clear() -> Result<(), String> {
+    // Clear all three: keychain, file cache, memory cache.
+    if let Ok(mut guard) = auth_cache().lock() {
+        *guard = None;
+    }
+    auth_file_cache_clear();
     let entry = auth_keychain_entry()?;
     match entry.delete_password() {
         Ok(()) => Ok(()),

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -20,6 +20,7 @@ export function CommandPalette() {
     appendToDraftPrompt,
     createSession,
     selectSession,
+    sendPrompt,
     daemon,
   } = useAppStore()
 
@@ -126,6 +127,28 @@ export function CommandPalette() {
                 className="cursor-pointer rounded-xl px-3 py-2 text-sm hover:bg-slate-100"
               >
                 New Session
+              </Command.Item>
+              <Command.Item
+                value="clear conversation"
+                onSelect={() => {
+                  setOpen(false)
+                  void sendPrompt('/clear')
+                }}
+                className="cursor-pointer rounded-xl px-3 py-2 text-sm hover:bg-slate-100"
+              >
+                <div className="font-mono">/clear</div>
+                <div className="text-xs text-[color:var(--color-text-muted)]">Clear conversation history</div>
+              </Command.Item>
+              <Command.Item
+                value="compact context compress"
+                onSelect={() => {
+                  setOpen(false)
+                  appendToDraftPrompt('/compact ')
+                }}
+                className="cursor-pointer rounded-xl px-3 py-2 text-sm hover:bg-slate-100"
+              >
+                <div className="font-mono">/compact</div>
+                <div className="text-xs text-[color:var(--color-text-muted)]">Compact conversation context (add instruction after command)</div>
               </Command.Item>
             </Command.Group>
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -362,12 +362,21 @@ export function SettingsView() {
 
   const refreshAccount = async () => {
     if (!daemon) return
+    if (!authService.isLoggedIn()) {
+      setAccount(null)
+      return
+    }
     setAccountLoading(true)
     try {
       const res = await daemon.accountGet()
       setAccount(res)
     } catch (e) {
-      setAccount({ planError: e instanceof Error ? e.message : 'Failed to load account' })
+      const msg = e instanceof Error ? e.message : 'Failed to load account'
+      // Provide a user-friendly message for gRPC connection errors.
+      const friendly = msg.includes('content-type mismatch') || msg.includes('grpc')
+        ? 'Unable to reach account server. Please check your network connection and try again.'
+        : msg
+      setAccount({ planError: friendly })
     } finally {
       setAccountLoading(false)
     }

--- a/src/lib/daemon.ts
+++ b/src/lib/daemon.ts
@@ -398,4 +398,14 @@ export class DaemonClient {
   async queueClear(): Promise<{ status: 'ok' }> {
     return this.request('queue.clear')
   }
+
+  async conversationClear(): Promise<{ status: 'ok' }> {
+    return this.request('conversation.clear')
+  }
+
+  async conversationCompact(params?: {
+    instruction?: string
+  }): Promise<{ status: 'ok'; summary?: string }> {
+    return this.request('conversation.compact', params)
+  }
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2427,6 +2427,60 @@ export const useAppStore = create<AppState>()(
           }
         }
 
+        // ── /clear: reset conversation history ──
+        if (trimmed === '/clear') {
+          try {
+            await daemon.conversationClear()
+          } catch (e) {
+            console.warn('[store] conversation.clear failed:', e)
+          }
+          set((st) => ({
+            sessions: st.sessions.map((s) =>
+              s.id === sessionId
+                ? { ...s, messages: [], agentEvents: [], updatedAt: now() }
+                : s,
+            ),
+            currentRunId: null,
+            currentRunStatus: 'idle',
+            modifiedFilesByPath: {},
+            pendingApprovals: [],
+            clarifyingQuestions: [],
+            lastToast: { title: 'Conversation cleared', message: 'All messages have been removed from this session.' },
+          }))
+          return
+        }
+
+        // ── /compact: compress conversation context ──
+        if (trimmed === '/compact' || trimmed.startsWith('/compact ')) {
+          const instruction = trimmed === '/compact' ? undefined : trimmed.slice('/compact '.length).trim() || undefined
+          const userMsg: ChatMessage = {
+            id: crypto.randomUUID(),
+            role: 'user',
+            content: trimmed,
+            createdAt: now(),
+          }
+          set((st) => ({ sessions: appendMessage(st.sessions, sessionId, userMsg) }))
+
+          try {
+            const res = await daemon.conversationCompact({ instruction })
+            const summaryText = res.summary
+              ? `Context compacted.\n\n**Summary preserved:**\n${res.summary}`
+              : 'Context compacted successfully.'
+            appendAssistantMessage(summaryText)
+            set({
+              lastToast: {
+                title: 'Context compacted',
+                message: instruction ? `Custom instruction applied: "${instruction}"` : 'Conversation context has been compressed.',
+              },
+            })
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e)
+            appendAssistantMessage(`Failed to compact context:\n${msg}`)
+            set({ error: msg })
+          }
+          return
+        }
+
         const queueLocalItem = (value: string, prepend = false) => {
           const item = value.trim()
           if (!item) return


### PR DESCRIPTION
## Changes

- **Backend Commands**: Added `conversation.clear()` and `conversation.compact()` gRPC methods
- **Keychain Caching**: Implemented three-tier auth caching (memory → file → keychain) to eliminate repeated macOS keychain prompts
- **Slash Commands**: 
  - `/clear` - Resets conversation history and clears session state
  - `/compact [instruction]` - Compresses conversation context with optional custom instruction
- **UI Updates**: Added command palette entries for new slash commands
- **Error Handling**: Improved gRPC error messages in account settings with user-friendly fallback text